### PR TITLE
feat(activity): differentiate error messages and add degraded streams state (SPEC-22)

### DIFF
--- a/src/features/activity/routes/ActivityDetail.tsx
+++ b/src/features/activity/routes/ActivityDetail.tsx
@@ -83,13 +83,17 @@ export function ActivityDetailPage() {
   const viewState = resolveRouteViewState(activityQuery, streamsQuery);
 
   if (viewState === 'error') {
+    const rawErrorMessage = activityQuery.error?.message ?? '';
+    const detailMessage =
+      rawErrorMessage.trim() !== ''
+        ? rawErrorMessage
+        : 'Se ha producido un error al cargar la actividad. Inténtalo de nuevo más tarde.';
+
     return (
       <div className="min-h-screen bg-bg-primary flex items-center justify-center">
         <div className="bg-bg-card border border-red-800 p-8 rounded-2xl text-center max-w-md">
           <p className="text-red-400">Actividad no disponible</p>
-          {activityQuery.error?.message && (
-            <p className="text-gray-400 mt-2 text-sm">{activityQuery.error.message}</p>
-          )}
+          <p className="text-gray-400 mt-2 text-sm">{detailMessage}</p>
           <button
             onClick={() => navigate({ to: '/' })}
             className="mt-4 px-4 py-2 bg-orange-500 text-black rounded-lg hover:bg-orange-400"

--- a/src/features/activity/routes/ActivityDetail.tsx
+++ b/src/features/activity/routes/ActivityDetail.tsx
@@ -32,7 +32,8 @@ function resolveRouteViewState<TActivity, TStreams>(
   activityQuery: QueryLike<TActivity>,
   streamsQuery: QueryLike<TStreams>
 ): RouteViewState {
-  if (activityQuery.isError || streamsQuery.isError) {
+  // Only activity errors are fatal — streams failure is a degraded-ready state, not a routing error
+  if (activityQuery.isError) {
     return 'error';
   }
 
@@ -82,13 +83,13 @@ export function ActivityDetailPage() {
   const viewState = resolveRouteViewState(activityQuery, streamsQuery);
 
   if (viewState === 'error') {
-    const message = activityQuery.error?.message ?? streamsQuery.error?.message ?? 'No se pudo cargar la actividad';
-
     return (
       <div className="min-h-screen bg-bg-primary flex items-center justify-center">
         <div className="bg-bg-card border border-red-800 p-8 rounded-2xl text-center max-w-md">
-          <p className="text-red-400">Error al cargar la actividad</p>
-          <p className="text-gray-400 mt-2 text-sm">{message}</p>
+          <p className="text-red-400">Actividad no disponible</p>
+          {activityQuery.error?.message && (
+            <p className="text-gray-400 mt-2 text-sm">{activityQuery.error.message}</p>
+          )}
           <button
             onClick={() => navigate({ to: '/' })}
             className="mt-4 px-4 py-2 bg-orange-500 text-black rounded-lg hover:bg-orange-400"
@@ -143,6 +144,16 @@ export function ActivityDetailPage() {
 
   return (
     <div className="min-h-screen bg-bg-primary">
+      {/* Streams degraded banner */}
+      {streamsQuery.isError && (
+        <div className="bg-yellow-900/40 border-b border-yellow-700 px-4 py-3">
+          <p className="text-yellow-300 text-sm font-medium">Streams no disponibles</p>
+          {streamsQuery.error?.message && (
+            <p className="text-yellow-400/70 text-xs mt-1">{streamsQuery.error.message}</p>
+          )}
+        </div>
+      )}
+
       {/* Header */}
       <header className="bg-bg-card border-b border-border sticky top-0 z-10">
         <div className="max-w-2xl mx-auto px-4 py-4 flex items-center gap-4">

--- a/src/features/activity/routes/__tests__/ActivityDetail.state-contract.test.tsx
+++ b/src/features/activity/routes/__tests__/ActivityDetail.state-contract.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { ActivityDetailPage } from '../ActivityDetail';
 
 const mocks = vi.hoisted(() => ({
@@ -61,6 +61,10 @@ function sampleActivity(overrides: Record<string, unknown> = {}) {
 }
 
 describe('ActivityDetail route state contract', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.useActivityDetailMock.mockReturnValue(queryState({ isLoading: true }));
@@ -86,8 +90,41 @@ describe('ActivityDetail route state contract', () => {
 
     render(<ActivityDetailPage />);
 
-    expect(screen.getByText('Error al cargar la actividad')).toBeInTheDocument();
+    expect(screen.getByText('Actividad no disponible')).toBeInTheDocument();
+    expect(screen.getByText('detail transport failed')).toBeInTheDocument();
     expect(screen.queryByText('Analizando entrenamiento...')).not.toBeInTheDocument();
+  });
+
+  it('renders degraded ready state when only streams query fails', () => {
+    mocks.useActivityDetailMock.mockReturnValue(
+      queryState({ data: sampleActivity() })
+    );
+    mocks.useActivityStreamsMock.mockReturnValue(
+      queryState({ isError: true, error: new Error('Timeout al cargar streams') })
+    );
+
+    render(<ActivityDetailPage />);
+
+    expect(screen.getByText('Streams no disponibles')).toBeInTheDocument();
+    expect(screen.getByText('Timeout al cargar streams')).toBeInTheDocument();
+    expect(screen.getAllByText('DATOS DE LA ACTIVIDAD').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Actividad no disponible')).not.toBeInTheDocument();
+  });
+
+  it('shows activity error and hides streams banner when both queries fail', () => {
+    mocks.useActivityDetailMock.mockReturnValue(
+      queryState({ isError: true, error: new Error('Activity gone') })
+    );
+    mocks.useActivityStreamsMock.mockReturnValue(
+      queryState({ isError: true, error: new Error('Streams also gone') })
+    );
+
+    render(<ActivityDetailPage />);
+
+    expect(screen.getByText('Actividad no disponible')).toBeInTheDocument();
+    expect(screen.getByText('Activity gone')).toBeInTheDocument();
+    expect(screen.queryByText('Streams no disponibles')).not.toBeInTheDocument();
+    expect(screen.queryByText('DATOS DE LA ACTIVIDAD')).not.toBeInTheDocument();
   });
 
   it('renders loading when queries are pending with no errors', () => {


### PR DESCRIPTION
## Summary

- `resolveRouteViewState` now returns `'error'` only for activity query failures — streams errors are degraded-ready state, not fatal
- Error branch title changed to `"Actividad no disponible"` with `error.message` sub-line
- Streams failure renders a yellow warning banner (`"Streams no disponibles"`) inside the ready state, keeping activity content visible
- `RouteViewState` type unchanged (`'error' | 'loading' | 'not-found' | 'ready'`)

## Acceptance Criteria

- ✅ CA-01: `activityQuery.isError` → error state → "Actividad no disponible" + error.message
- ✅ CA-02: `streamsQuery.isError` only → ready state + warning banner + activity content visible
- ✅ CA-03: Both fail → activity error wins, no banner rendered
- ✅ CA-04: Happy path → no banner rendered

## Files Changed

- `src/features/activity/routes/ActivityDetail.tsx` — selector fix + error branch + degraded banner
- `src/features/activity/routes/__tests__/ActivityDetail.state-contract.test.tsx` — 1 updated + 2 new tests + afterEach(cleanup) fix

Closes SPEC-22